### PR TITLE
[BUGFIX] Do not restrict payload to multipart for POST actions.

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -130,24 +130,10 @@ const register = async (server: Hapi.Server, options: ExtendedAdminJSOptions) =>
   };
 
   routes.forEach((route) => {
-    const auth = resolveAuthOption(route);
-    const opts: RouteOptions =
-      route.method === 'POST'
-        ? {
-            auth,
-            payload: {
-              allow: 'multipart/form-data',
-              multipart: { output: 'stream' },
-            },
-          }
-        : {
-            auth,
-          };
-
     server.route({
       method: route.method,
       path: `${admin.options.rootPath}${route.path}`,
-      options: opts,
+      options: { auth: resolveAuthOption(route) },
       handler: async (request, h) => {
         try {
           const loggedInUser = request.auth?.credentials?.[0];


### PR DESCRIPTION
This bug has been spotted using hapijs, adminjs-hapijs and @adminjs/import-export plugins.
When doing so, the export feature of @adminjs/import-export fails with 415 status code.

After investigation, it appears that adminjs-hapijs restricts payload format for POST routes to multipart.

While this works well for classic CRUD actions, it does not work for every custom POST actions.

With this PR, the restriction about payload being multipart is removed.
