### PR TITLE
[BUGFIX] Correctly read request credentials.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1024pix/adminjs-hapijs",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "type": "module",
   "description": "This is an official AdminJS plugin which integrates it with hapijs framework.",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@adminjs/hapi",
+  "name": "@1024pix/adminjs-hapijs",
   "version": "7.0.0",
   "type": "module",
   "description": "This is an official AdminJS plugin which integrates it with hapijs framework.",

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -150,7 +150,7 @@ const register = async (server: Hapi.Server, options: ExtendedAdminJSOptions) =>
       options: opts,
       handler: async (request, h) => {
         try {
-          const loggedInUser = request.auth?.credentials?.[0];
+          const loggedInUser = request.auth?.credentials;
           const controller = new route.Controller({ admin }, loggedInUser);
           const ret = await controller[route.action](request, h);
           const response = h.response(ret);


### PR DESCRIPTION
When reading credentials from the auth object on request, we try to access the first element of an array.

Unfortunately, the credentials object is not an array but a plain object.

By returning directly the auth.credentials in the session auth strategy, we can now access the current admin in the rest of the code.
This means we can use the `useCurrentAdmin` in custom component or that the profile menu (on top right) is now displayed, letting user to log out.
