### PR TITLE
[BUGFIX] Correctly read request credentials. 

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -150,7 +150,9 @@ const register = async (server: Hapi.Server, options: ExtendedAdminJSOptions) =>
       options: opts,
       handler: async (request, h) => {
         try {
-          const loggedInUser = request.auth?.credentials;
+          const loggedInUser = Array.isArray(request.auth?.credentials)
+            ? request.auth?.credentials?.[0]
+            : request.auth?.credentials;
           const controller = new route.Controller({ admin }, loggedInUser);
           const ret = await controller[route.action](request, h);
           const response = h.response(ret);

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -150,7 +150,7 @@ const register = async (server: Hapi.Server, options: ExtendedAdminJSOptions) =>
       options: opts,
       handler: async (request, h) => {
         try {
-          const loggedInUser = request.auth?.credentials?.[0];
+          const loggedInUser = request.auth?.credentials;
           const controller = new route.Controller({ admin }, loggedInUser);
           const ret = await controller[route.action](request, h);
           const response = h.response(ret);


### PR DESCRIPTION
When reading credentials from the auth object on request, we try to access the first element of an array.

Unfortunately, the credentials object is not an array but a plain object.

By returning directly the auth.credentials in the session auth strategy, we can now access the current admin in the rest of the code.
This means we can use the `useCurrentAdmin` in custom component or that the profile menu (on top right) is now displayed, letting user to log out.