### PR TITLE
[BUGFIX] Allow delete action

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -165,7 +165,7 @@ const register = async (server: Hapi.Server, options: ExtendedAdminJSOptions) =>
         ? {
             auth,
             payload: {
-              allow: 'multipart/form-data',
+              allow: ['multipart/form-data', 'application/json'],
               multipart: { output: 'stream' },
             },
           }


### PR DESCRIPTION
When the delete action is sent, it does not contain a payload, which is not allowed by the current configuration resulting in a 415 Unsupported Media Type error

![Screenshot 2024-06-13 at 14 32 18](https://github.com/SoftwareBrothers/adminjs-hapijs/assets/26384707/77265927-8baa-4891-9631-c8ff464ceebe)
